### PR TITLE
Added -lm to plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Airwindows.lv2)
 function(add_plugin PLUGIN_NAME)
   add_library(${PLUGIN_NAME} SHARED src/${PLUGIN_NAME}/${PLUGIN_NAME}.c)
   target_include_directories(${PLUGIN_NAME} PRIVATE ${LV2_INCLUDE_DIRS})
+  target_link_libraries(${PLUGIN_NAME} m)
   set_target_properties(${PLUGIN_NAME} PROPERTIES PREFIX "")
 
   if(MSVC)


### PR DESCRIPTION
Hello and thank you for this much needed port! I am packaging this for openSUSE but my build failed because of undefined references to the various `math.h` functions (like `pow`). The reason is that `#include <math.h>` is not enough, the math library has to be linked too (`-lm`). This little fix takes care of that.